### PR TITLE
use proper credential passing as per API docs

### DIFF
--- a/lib/pardot/http.rb
+++ b/lib/pardot/http.rb
@@ -4,7 +4,7 @@ module Pardot
     def get object, path, params = {}, num_retries = 0
       smooth_params object, params
       full_path = fullpath object, path
-      check_response self.class.get(full_path, :query => params)
+      check_response self.class.get(full_path, :query => params, :headers => { 'Authorization' => "Pardot api_key=#{@api_key}, user_key=#{@user_key}" })
 
     rescue Pardot::ExpiredApiKeyError => e
       handle_expired_api_key :get, object, path, params, num_retries, e
@@ -16,7 +16,7 @@ module Pardot
     def post object, path, params = {}, num_retries = 0, bodyParams = {}
       smooth_params object, params
       full_path = fullpath object, path
-      check_response self.class.post(full_path, :query => params, :body => bodyParams)
+      check_response self.class.post(full_path, :query => params, :body => bodyParams.merge(:user_key => @user_key, :api_key => @api_key))
 
     rescue Pardot::ExpiredApiKeyError => e
       handle_expired_api_key :post, object, path, params, num_retries, e
@@ -39,7 +39,7 @@ module Pardot
       return if object == "login"
 
       authenticate unless authenticated?
-      params.merge! :user_key => @user_key, :api_key => @api_key, :format => @format
+      params.merge! :format => @format
     end
 
     def check_response http_response


### PR DESCRIPTION
- GET should pass credentials in a header
- POST should pass credentials in body

as per: http://developer.pardot.com/#using-the-api

This fixes an issue where API v3 orgs return `Access Denied` (error 49 from http://developer.pardot.com/kb/error-codes-messages/) when hitting the `/customField` endpoint.